### PR TITLE
Updating the mpiserial check for mpi-serial2.0

### DIFF
--- a/TryMPISERIAL.f90
+++ b/TryMPISERIAL.f90
@@ -1,14 +1,12 @@
-! Test for the mct mpiserial stubs library
-! in which mpi_integer == mpi_real4 and the select will
-! fail to compile. (PGI doesnt complain so add something 
-! it will complain about
+! Test for the mct mpiserial library
+! in which mpi_cart is not defined (and likely never will be)
+! Failure to compile means mpi-serial is being used.
 !
 program mpiserial_test
  implicit none
  include 'mpif.h' 
  integer :: i
  select case(i)
- case(mpi_integer)
- case(mpi_real4)
+ case(mpi_cart)
  end select
 end program mpiserial_test


### PR DESCRIPTION
TryMPISERIAL.f90 is supposed to fail to compile with mpi-serial
to let the PIO configure (with CMake) know that it should set its
build for mpi-serial. The previous version compiled successfully
with mpi-serial2.0 . We now use an MPI type not defined in the
mpi serial library instead of equivalence of two MPI types in
the mpiserial library to make sure that the code fails to compile
with the mpiserial library.

Thanks Rob Jacob@ANL for the fix.