### PR TITLE
Bring in latest changes from CIME

### DIFF
--- a/FindNETCDF.cmake
+++ b/FindNETCDF.cmake
@@ -7,6 +7,11 @@
 #  NETCDF_LIBRARIES - All the libraries needed to use Netcdf
 #  NETCDF_DEFINITIONS - Compiler switches required for using Netcdf
 
+# If we weren't given a hint via a CMake variable, check the environment.
+if(NOT NETCDF_DIR)
+  set(NETCDF_DIR $ENV{NETCDF})
+endif()
+
 find_path(NETCDF_INCLUDE_DIR netcdf.h
           HINTS ${NETCDF_DIR}/include )
 
@@ -17,7 +22,7 @@ find_path(NETCDF_FORTRAN_LIB_DIR NAMES libnetcdff.a libnetcdff.so
           HINTS ${NETCDF_DIR}/lib ${NETCDF_DIR}/lib64 )
 
 
-find_file(NETCDF4_PAR_H netcdf_par.h 
+find_file(NETCDF4_PAR_H netcdf_par.h
           HINTS ${NETCDF_INCLUDE_DIR}
           NO_DEFAULT_PATH )
 
@@ -25,11 +30,10 @@ find_file(NETCDF4_PAR_H netcdf_par.h
 find_library(NETCDF_C_LIBRARY NAMES libnetcdf.a netcdf HINTS ${NETCDF_LIB_DIR})
 
 if(NOT NETCDF_FORTRAN_LIB_DIR)
-  MESSAGE("WARNING: did not find netcdf fortran library")
+  MESSAGE(WARNING "Did not find netCDF Fortran library.")
 else()
   find_library(NETCDF_Fortran_LIBRARY NAMES libnetcdff.a netcdff HINTS ${NETCDF_FORTRAN_LIB_DIR})
 endif()
-set(NETCDF_LIBRARIES ${NETCDF_Fortran_LIBRARY} ${NETCDF_C_LIBRARY})
 if(NOT NETCDF4_PAR_H)
   set(NETCDF4_PARALLEL "no")
   MESSAGE("NETCDF built without MPIIO")
@@ -40,12 +44,31 @@ endif()
 
 set(NETCDF_INCLUDE_DIRS ${NETCDF_INCLUDE_DIR} )
 
-FIND_PACKAGE(HDF5 COMPONENTS C HL)
+FIND_PACKAGE(HDF5 COMPONENTS C HL CONFIG)
 
-if(${HDF5_FOUND}) 
+if(${HDF5_FOUND})
   MESSAGE(STATUS "Adding hdf5 libraries ")
- set(NETCDF_C_LIBRARY ${NETCDF_C_LIBRARY} ${HDF5_LIBRARIES})  
+ set(NETCDF_C_LIBRARY ${NETCDF_C_LIBRARY} ${HDF5_LIBRARIES}
+                      ${SZIP_LIBRARIES} ${ZLIB_LIBRARIES})
 endif()
+
+# If netCDF was configured with DAP, it depends on libcurl.
+find_program(NETCDF_NC_CONFIG nc-config HINTS ${NETCDF_INCLUDE_DIR}/../bin)
+if(NETCDF_NC_CONFIG)
+  execute_process(COMMAND ${NETCDF_NC_CONFIG} --has-dap
+    OUTPUT_VARIABLE nc_config_output)
+  if(nc_config_output MATCHES yes)
+    find_package(CURL)
+    if(CURL_FOUND)
+      MESSAGE(STATUS "Adding curl libraries for netCDF DAP.")
+      set(NETCDF_C_LIBRARY ${NETCDF_C_LIBRARY} ${CURL_LIBRARIES})
+    else()
+      MESSAGE(WARNING "netCDF DAP appears enabled, but libcurl was not found.")
+    endif()
+  endif()
+endif()
+
+set(NETCDF_LIBRARIES ${NETCDF_Fortran_LIBRARY} ${NETCDF_C_LIBRARY})
 
 # Export variables so other projects can use them as well
 #  ie. if pio is added with add_subdirectory

--- a/pFUnit_utils.cmake
+++ b/pFUnit_utils.cmake
@@ -50,8 +50,14 @@
 #    COMMAND - Command to run the pFUnit test
 #       - Defaults to executable_name
 #       - Needs to be given if you need more on the command line than just the executable
-#         name, such as an aprun command, or setting the number of threads
+#         name, such as setting the number of threads
 #       - A multi-part command should NOT be enclosed in quotes (see example below)
+#       - COMMAND should NOT contain the mpirun command: this is specified
+#         separately, via the PFUNIT_MPIRUN CMake variable
+#
+# Non-standard CMake variables used:
+#    PFUNIT_MPIRUN - If executables need to be prefixed with an mpirun command,
+#      PFUNIT_MPIRUN gives this prefix (e.g., "mpirun")
 #
 # Does everything needed to create a pFUnit-based test, wrapping
 # add_pFUnit_executable, add_test, and define_pFUnit_failure. 
@@ -182,6 +188,9 @@ endfunction(define_pFUnit_failure)
 #
 # Optional input variables are GEN_OUTPUT_DIRECTORY and COMMAND (see usage notes at the
 # top of this file for details).
+#
+# If executables need to be prefixed with an mpirun command, this prefix (e.g.,
+# "mpirun") should be given in the CMAKE variable PFUNIT_MPIRUN.
 function(create_pFUnit_test test_name executable_name pf_file_list fortran_source_list)
 
   # Parse optional arguments
@@ -202,6 +211,9 @@ function(create_pFUnit_test test_name executable_name pf_file_list fortran_sourc
   if (NOT MY_COMMAND)
     set(MY_COMMAND ${executable_name})
   endif()
+
+  # Prefix command with an mpirun command
+  set (MY_COMMAND ${PFUNIT_MPIRUN} ${MY_COMMAND})
 
   # Do the work
   add_pFUnit_executable(${executable_name} "${pf_file_list}"


### PR DESCRIPTION
My intention was to bring in the changes from https://github.com/CESM-Development/cime/pull/87  – create_pFUnit_test now adds an mpirun prefix to the command used to run tests.

However, I guess there have also been some other changes in cime from @quantheory  that were never pushed to CMake_Fortran_utils. So those appear to be folded in here as well.

The log messages are a little confusing, since they refer to changes that were made elsewhere in cime in the same commit. I'm not sure if this is something we want to worry about, and if so what is the best thing to do about it at this point? ( @quantheory suggested splitting commits?)

As a side-note, I notice that there is an mpiexec.cmake file. I'm not sure whether this should be used in create_pFUnit_test, and if so, how: I don't see any examples of its use yet.