### PR TITLE
Replace mpif.h with the MPI module.

### DIFF
--- a/TryMPIIO.f90
+++ b/TryMPIIO.f90
@@ -1,5 +1,5 @@
 program mpicheck
-  include "mpif.h"
+  use mpi
   integer :: fh, ierr
   
   call mpi_file_open(mpi_comm_world, 'stupid.file',MPI_MODE_RDWR,MPI_INFO_NULL,fh,ierr)

--- a/TryMPISERIAL.f90
+++ b/TryMPISERIAL.f90
@@ -3,8 +3,8 @@
 ! Failure to compile means mpi-serial is being used.
 !
 program mpiserial_test
+ use mpi
  implicit none
- include 'mpif.h' 
  integer :: i
  select case(i)
  case(mpi_cart)


### PR DESCRIPTION
The use of mpif.h is strongly discouraged by the [standard](https://www.mpi-forum.org/docs/mpi-3.1/mpi31-report/node411.htm). Would you consider replacing it with the `use mpi`?